### PR TITLE
Implement last satisfying version

### DIFF
--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -37,6 +37,12 @@ function findSpecific (allVersions, version) {
   const versionObj = allVersions.versions[version];
 
   if (!versionObj) {
+    if (version.startsWith("<")) {
+      const lastSatisfyingVersion = semver.maxSatisfying(allVersions, version);
+      if (!lastSatisfyingVersion) {
+        return lastSatisfyingVersion;      
+      }
+    }
     throw new Error(`Could not find Terraform version ${version} in version list`);
   }
 


### PR DESCRIPTION
This PR implements a "last Satisfying" check. It allows to specify a "<1.13.0" for example to limit installation to latest released 1.12.* version.